### PR TITLE
Make checks for propagation headers case insensitive

### DIFF
--- a/tck/tracing/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/B3MultiPropagationTest.java
+++ b/tck/tracing/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/B3MultiPropagationTest.java
@@ -112,8 +112,11 @@ public class B3MultiPropagationTest extends Arquillian {
         Assert.assertNull(server.getAttributes().get(BAGGAGE_METADATA_ATTR));
 
         // Assert that the expected headers were used
-        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).contains("X-B3-TraceId"));
-        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).contains("X-B3-SpanId"));
-        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).contains("X-B3-Sampled"));
+        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).stream()
+                .anyMatch(x -> x.equalsIgnoreCase("X-B3-TraceId")));
+        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).stream()
+                .anyMatch(x -> x.equalsIgnoreCase("X-B3-SpanId")));
+        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).stream()
+                .anyMatch(x -> x.equalsIgnoreCase("X-B3-Sampled")));
     }
 }

--- a/tck/tracing/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/B3PropagationTest.java
+++ b/tck/tracing/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/B3PropagationTest.java
@@ -111,7 +111,8 @@ public class B3PropagationTest extends Arquillian {
 
         // Assert that the expected headers were used
         Assert.assertTrue(
-                server.getAttributes().get(AttributeKey.stringArrayKey("test.propagation.headers")).contains("b3"));
+                server.getAttributes().get(AttributeKey.stringArrayKey("test.propagation.headers")).stream()
+                        .anyMatch(x -> x.equalsIgnoreCase("b3")));
 
     }
 }

--- a/tck/tracing/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/JaegerPropagationTest.java
+++ b/tck/tracing/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/JaegerPropagationTest.java
@@ -112,7 +112,9 @@ public class JaegerPropagationTest extends Arquillian {
         Assert.assertEquals(server.getAttributes().get(BAGGAGE_METADATA_ATTR), "");
 
         // assert that the expected headers were used
-        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).contains("uber-trace-id"));
-        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).contains("uberctx-" + BAGGAGE_KEY));
+        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).stream()
+                .anyMatch(x -> x.equalsIgnoreCase("uber-trace-id")));
+        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).stream()
+                .anyMatch(x -> x.equalsIgnoreCase("uberctx-" + BAGGAGE_KEY)));
     }
 }

--- a/tck/tracing/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/W3BaggagePropagationTest.java
+++ b/tck/tracing/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/W3BaggagePropagationTest.java
@@ -111,7 +111,9 @@ public class W3BaggagePropagationTest extends Arquillian {
         Assert.assertEquals(server.getAttributes().get(BAGGAGE_METADATA_ATTR), BAGGAGE_METADATA);
 
         // Assert that the expected headers were used
-        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).contains("traceparent"));
-        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).contains("baggage"));
+        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).stream()
+                .anyMatch(x -> x.equalsIgnoreCase("traceparent")));
+        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).stream()
+                .anyMatch(x -> x.equalsIgnoreCase("baggage")));
     }
 }

--- a/tck/tracing/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/W3PropagationTest.java
+++ b/tck/tracing/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/W3PropagationTest.java
@@ -112,6 +112,7 @@ public class W3PropagationTest extends Arquillian {
         Assert.assertNull(server.getAttributes().get(BAGGAGE_METADATA_ATTR));
 
         // Assert that the expected headers were used
-        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).contains("traceparent"));
+        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).stream()
+                .anyMatch(x -> x.equalsIgnoreCase("traceparent")));
     }
 }


### PR DESCRIPTION
Fixes #289 